### PR TITLE
fix: check vector length instead of newline

### DIFF
--- a/src/utils/terminal.rs
+++ b/src/utils/terminal.rs
@@ -48,14 +48,12 @@ pub fn run_terminal() ->  Result<(),Error> {
                 eprintln!("ERROR: failed to read line : {}", e);
                 return Err(e);
         }
-        
-
-        if input == "\n" {
-            continue;
-        }
 
         //Config::parser cmd_args
         let parts : Vec<&str>  = input.trim().split_whitespace().collect();
+		if parts.len() == 0 {
+			continue;
+		}
         let command = *parts.first().unwrap(); //will always  succeed , handled  by prior if condition
         let args = match &parts {
             p if p.len() > 1 => &p[1..],


### PR DESCRIPTION
This will fix an annoying panic. It was panicking because "\n" is not the only possible string that yields an empty vector after a split_whitespace operation (try with only spaces or tabs and see what I mean bro).